### PR TITLE
fix table height on job history

### DIFF
--- a/src/main/resources/io/jenkins/plugins/agent_build_history/agentBuildHistory.css
+++ b/src/main/resources/io/jenkins/plugins/agent_build_history/agentBuildHistory.css
@@ -13,6 +13,10 @@
   column-gap: 20px;
 }
 
+.abh-job-history {
+  height: fit-content;
+}
+
 .abh-job-history tbody>tr>td {
   height: auto!important;
 }


### PR DESCRIPTION
the table on the job history has huge row height when there are less than 6 or 7 runs.

Before:
![image](https://github.com/jenkinsci/pipeline-agent-build-history-plugin/assets/17767050/60331060-cbd0-42fc-bd17-d25c0875fed3)

After:
![image](https://github.com/jenkinsci/pipeline-agent-build-history-plugin/assets/17767050/b957e205-e15a-4b9c-b177-17ff214e50b5)


### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
