### PR TITLE
avoid failure with full checkout of Jenkinsfile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.76</version>
+    <version>4.78</version>
     <relativePath/>
   </parent>
 
@@ -34,7 +34,7 @@
 
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
-    <jenkins.version>2.434</jenkins.version>
+    <jenkins.version>2.440.1</jenkins.version>
     <gitHubRepo>jenkinsci/pipeline-agent-build-history-plugin</gitHubRepo>
   </properties>
 
@@ -42,8 +42,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-weekly</artifactId>
-        <version>2661.vb_b_60650f6d97</version>
+        <artifactId>bom-2.440.x</artifactId>
+        <version>2839.v003b_4d9d24fd</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/main/java/io/jenkins/plugins/agent_build_history/AgentBuildHistory.java
+++ b/src/main/java/io/jenkins/plugins/agent_build_history/AgentBuildHistory.java
@@ -87,6 +87,9 @@ public class AgentBuildHistory implements Action {
           AgentExecution execution = new AgentExecution(wfr);
           boolean matchesNode = false;
           for (FlowNode flowNode : new DepthFirstScanner().allNodes(flowExecution)) {
+            if (! (flowNode instanceof StepStartNode)) {
+              continue;
+            }
             for (WorkspaceActionImpl action : flowNode.getActions(WorkspaceActionImpl.class)) {
               StepStartNode startNode = (StepStartNode) flowNode;
               StepDescriptor descriptor = startNode.getDescriptor();

--- a/src/main/java/io/jenkins/plugins/agent_build_history/WorkflowJobTrend.java
+++ b/src/main/java/io/jenkins/plugins/agent_build_history/WorkflowJobTrend.java
@@ -78,6 +78,9 @@ public class WorkflowJobTrend extends ProgressiveRendering {
         FlowExecution flowExecution = run.getExecution();
         if (flowExecution != null) {
             for (FlowNode flowNode : new DepthFirstScanner().allNodes(flowExecution)) {
+                if (! (flowNode instanceof StepStartNode)) {
+                  continue;
+                }
                 JSONObject n = new JSONObject();
                 WorkspaceActionImpl action = flowNode.getAction(WorkspaceActionImpl.class);
                 if (action != null) {


### PR DESCRIPTION
when a pipeline checks out the Jenkinsfile with a full checkout and not a lightweight, the FlowStartNode actually gets a workspace assigned. This is not a usage of the built-in node that should be tracked so we just ignore everything that is not the correct type.

update to depend on 2.440.1 instead of a weekly

fixes #21 
<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
