### PR TITLE
fix hint url and improve hint

### DIFF
--- a/src/main/java/io/jenkins/plugins/agent_build_history/AgentBuildHistory.java
+++ b/src/main/java/io/jenkins/plugins/agent_build_history/AgentBuildHistory.java
@@ -44,6 +44,8 @@ public class AgentBuildHistory implements Action {
   private final Computer computer;
 
   private static boolean loaded = false;
+  
+  private static boolean loadingComplete = false;
 
   @Extension
   public static class HistoryRunListener extends RunListener<Run<?, ?>> {
@@ -75,6 +77,10 @@ public class AgentBuildHistory implements Action {
    */
   public Computer getComputer() {
     return computer;
+  }
+
+  public boolean isLoadingComplete() {
+    return loadingComplete;
   }
 
   @SuppressFBWarnings(value = "ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD")
@@ -122,6 +128,7 @@ public class AgentBuildHistory implements Action {
         }
       }
     });
+    loadingComplete = true;
   }
 
   private static Set<AgentExecution> loadExecutions(String computerName) {

--- a/src/main/resources/io/jenkins/plugins/agent_build_history/AgentBuildHistory/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/agent_build_history/AgentBuildHistory/index.jelly
@@ -22,10 +22,14 @@
       <h1>
         ${%title(it.computer.displayName)}
       </h1>
-        <div class="tr jenkins-!-margin-bottom-3">
-          <em>${%disclaimer}</em><a tooltip="${%Missing some runs?}" helpurl="/jenkins/plugin/pipeline-agent-build-history/help/hint.html" href="#" class="jenkins-help-button" tabindex="9999"><span>?</span></a>
-        </div>
-        <div class="help-area tr" style="max-width: 750px;"><div class="help"><p class="jenkins-spinner">Loading...</p></div></div>
+      <div class="tr jenkins-!-margin-bottom-3">
+        <em>${%disclaimer}</em>
+        <j:if test="${!it.loadingComplete}">
+          <a tooltip="${%History loading still ongoing}" helpurl="${rootURL}/plugin/pipeline-agent-build-history/help/hint.html" href="#" class="jenkins-help-button" tabindex="9999">
+          <span class="abh-not-loaded">?</span></a>
+        </j:if>
+      </div>
+      <div class="help-area tr" style="max-width: 750px;"><div class="help"><p class="jenkins-spinner">Loading...</p></div></div>
 
       <t:setIconSize/>
       <st:adjunct includes="io.jenkins.plugins.agent_build_history.agentBuildHistory" />

--- a/src/main/resources/io/jenkins/plugins/agent_build_history/agentBuildHistory.css
+++ b/src/main/resources/io/jenkins/plugins/agent_build_history/agentBuildHistory.css
@@ -36,3 +36,7 @@
 .abh-list__button button[data-hidden=false] {
     rotate: 180deg;
 }
+
+.abh-not-loaded {
+  background: var(--error-color)!important;
+}

--- a/src/main/webapp/help/hint.html
+++ b/src/main/webapp/help/hint.html
@@ -1,6 +1,6 @@
 <div>
-  The very first extended build history page that is opened after Jenkins started will contain only those runs that have
-  started since then. A background job is started that will read the complete history of all jobs. It can take a few moments
-  until all data is loaded (depends on the total number of runs in the instance). A refresh of the page should show the complete
-  history usually.
+  The very first time an extended build history page of an agent is opened (it doesn't matter which agent), it contains only those runs that have
+  started since Jenkins startup. A background job is then started that will read the complete history of all jobs.
+  Depending on the total number of runs this can take a considerable amount of time. The help icon which showed this help area will
+  be only available while loading hasn't completed.
 </div>


### PR DESCRIPTION
the url to show the hint when the history wasn't loaded yet was not working properly.
The hint is now only available while the history loading hasn't completed.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
