### PR TITLE
don't log each pipeline run as using built-in

### DIFF
--- a/src/main/java/io/jenkins/plugins/agent_build_history/AgentBuildHistoryListeners.java
+++ b/src/main/java/io/jenkins/plugins/agent_build_history/AgentBuildHistoryListeners.java
@@ -109,7 +109,7 @@ public class AgentBuildHistoryListeners {
     public void taskStarted(Executor executor, Queue.Task task) {
       Queue.Executable executable = executor.getCurrentExecutable();
       Computer c = executor.getOwner();
-      if (executable instanceof Run<?, ?> run) {
+      if (executable instanceof Run<?, ?> run && !(executable instanceof WorkflowRun)) {
         LOGGER.log(Level.FINER, () -> "Starting Job: " + run.getFullDisplayName() + " on " + c.getName());
         AgentBuildHistory.startJobExecution(c, run);
       } else if (task instanceof ExecutorStepExecution.PlaceholderTask pht) {


### PR DESCRIPTION
A pipeline always initially starts running on the built-in controller using a fly-weight executor. It makes no sense to record those execution. This only blows up the record history of built-in

fixes #158
<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
