### PR TITLE
Don't create index file for non existing agents

### DIFF
--- a/src/main/java/io/jenkins/plugins/agent_build_history/AgentBuildHistory.java
+++ b/src/main/java/io/jenkins/plugins/agent_build_history/AgentBuildHistory.java
@@ -280,7 +280,11 @@ public class AgentBuildHistory implements Action {
               StepDescriptor descriptor = startNode.getDescriptor();
               if (descriptor instanceof ExecutorStep.DescriptorImpl) {
                 String nodeName = action.getNode();
-                BuildHistoryFileManager.addRunToNodeIndex(nodeName, run, AgentBuildHistoryConfig.get().getStorageDir());
+                Node node = Jenkins.get().getNode(nodeName);
+                // empty node name means it was run on built-in
+                if (nodeName.isBlank() || node != null) {
+                  BuildHistoryFileManager.addRunToNodeIndex(nodeName, run, AgentBuildHistoryConfig.get().getStorageDir());
+                }
               }
             }
           }

--- a/src/main/java/io/jenkins/plugins/agent_build_history/BuildHistoryFileManager.java
+++ b/src/main/java/io/jenkins/plugins/agent_build_history/BuildHistoryFileManager.java
@@ -1,5 +1,6 @@
 package io.jenkins.plugins.agent_build_history;
 
+import hudson.model.Node;
 import hudson.model.Result;
 import hudson.model.Run;
 import java.io.BufferedWriter;
@@ -17,6 +18,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 
 public class BuildHistoryFileManager {
@@ -92,18 +94,21 @@ public class BuildHistoryFileManager {
         action.addAgent(nodeName);
       }
     }
-    synchronized (lock) {
-      // Update index for the node
-      File indexFile = new File(storageDir + "/" + nodeName + "_index" + ".txt");
-      List<String> lines = readIndexFile(nodeName, storageDir);
-      String lineMatch = run.getParent().getFullName() + separator + run.getNumber() + separator;
-      boolean exists = lines.stream().anyMatch(line -> line.startsWith(lineMatch));
-      if (!exists) {
-        try (BufferedWriter writer = new BufferedWriter(new FileWriter(indexFile, StandardCharsets.UTF_8, true))) {
-          writeLine(writer, run);
-          writer.newLine();
-        } catch (IOException e) {
-          LOGGER.log(Level.WARNING, "Failed to update index for node " + nodeName, e);
+    Node node = Jenkins.get().getNode(nodeName);
+    if (node != null) {
+      synchronized (lock) {
+        // Update index for the node
+        File indexFile = new File(storageDir + "/" + nodeName + "_index" + ".txt");
+        List<String> lines = readIndexFile(nodeName, storageDir);
+        String lineMatch = run.getParent().getFullName() + separator + run.getNumber() + separator;
+        boolean exists = lines.stream().anyMatch(line -> line.startsWith(lineMatch));
+        if (!exists) {
+          try (BufferedWriter writer = new BufferedWriter(new FileWriter(indexFile, StandardCharsets.UTF_8, true))) {
+            writeLine(writer, run);
+            writer.newLine();
+          } catch (IOException e) {
+            LOGGER.log(Level.WARNING, "Failed to update index for node " + nodeName, e);
+          }
         }
       }
     }

--- a/src/main/java/io/jenkins/plugins/agent_build_history/BuildHistoryFileManager.java
+++ b/src/main/java/io/jenkins/plugins/agent_build_history/BuildHistoryFileManager.java
@@ -1,6 +1,5 @@
 package io.jenkins.plugins.agent_build_history;
 
-import hudson.model.Node;
 import hudson.model.Result;
 import hudson.model.Run;
 import java.io.BufferedWriter;
@@ -18,7 +17,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 
 public class BuildHistoryFileManager {
@@ -94,21 +92,18 @@ public class BuildHistoryFileManager {
         action.addAgent(nodeName);
       }
     }
-    Node node = Jenkins.get().getNode(nodeName);
-    if (node != null) {
-      synchronized (lock) {
-        // Update index for the node
-        File indexFile = new File(storageDir + "/" + nodeName + "_index" + ".txt");
-        List<String> lines = readIndexFile(nodeName, storageDir);
-        String lineMatch = run.getParent().getFullName() + separator + run.getNumber() + separator;
-        boolean exists = lines.stream().anyMatch(line -> line.startsWith(lineMatch));
-        if (!exists) {
-          try (BufferedWriter writer = new BufferedWriter(new FileWriter(indexFile, StandardCharsets.UTF_8, true))) {
-            writeLine(writer, run);
-            writer.newLine();
-          } catch (IOException e) {
-            LOGGER.log(Level.WARNING, "Failed to update index for node " + nodeName, e);
-          }
+    synchronized (lock) {
+      // Update index for the node
+      File indexFile = new File(storageDir + "/" + nodeName + "_index" + ".txt");
+      List<String> lines = readIndexFile(nodeName, storageDir);
+      String lineMatch = run.getParent().getFullName() + separator + run.getNumber() + separator;
+      boolean exists = lines.stream().anyMatch(line -> line.startsWith(lineMatch));
+      if (!exists) {
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(indexFile, StandardCharsets.UTF_8, true))) {
+          writeLine(writer, run);
+          writer.newLine();
+        } catch (IOException e) {
+          LOGGER.log(Level.WARNING, "Failed to update index for node " + nodeName, e);
         }
       }
     }


### PR DESCRIPTION
We delete the index file when an agent disappears. But when the load function adds something, it might create an index file for non existing agents. This only leads to creation of unneeded index files. This happens mostly for cloud agents that come and go and usually have random names so it is unlikely thee index file is ever needed again

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
