### PR TITLE
Don't recreate the index files when they have been loaded already.

### DIFF
--- a/src/main/java/io/jenkins/plugins/agent_build_history/AgentBuildHistory.java
+++ b/src/main/java/io/jenkins/plugins/agent_build_history/AgentBuildHistory.java
@@ -11,6 +11,9 @@ import hudson.model.Result;
 import hudson.model.Run;
 import hudson.util.RunList;
 import jakarta.servlet.http.Cookie;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -258,8 +261,15 @@ public class AgentBuildHistory implements Action {
     return execution;
   }
 
-  private static void load() {
-    LOGGER.log(Level.INFO, () -> "Starting to synchronize all runs");
+  private static synchronized void load() {
+    String storageDir = AgentBuildHistoryConfig.get().getStorageDir();
+    File marker = new File(storageDir + File.separator + "loaded.marker");
+    if (marker.exists()) {
+      LOGGER.log(Level.FINER, () -> "Loading marker file found, skipping synchronization of runs");
+      loadingComplete = true;
+      return;
+    }
+    LOGGER.log(Level.FINER, () -> "Starting to synchronize all runs");
     RunList<Run<?, ?>> runList = RunList.fromJobs((Iterable) Jenkins.get().allItems(Job.class));
     runList.forEach(run -> {
       LOGGER.finer("Loading run " + run.getFullDisplayName());
@@ -292,7 +302,12 @@ public class AgentBuildHistory implements Action {
       }
     });
     loadingComplete = true;
-    LOGGER.log(Level.INFO, () -> "Synchronizing all runs complete");
+    try {
+      Files.createFile(marker.toPath());
+    } catch (IOException e) {
+      LOGGER.log(Level.WARNING, () -> "Failed to create marker file.");
+    }
+    LOGGER.log(Level.FINER, () -> "Synchronizing all runs complete");
   }
 
   public static void startJobExecution(Computer c, Run<?, ?> run) {


### PR DESCRIPTION
Loading the history means looping over all runs of all jobs. This is a slow and expensive operation. When have indexed before successfully there is no need to do this.
Creates a marker file that when existing prevents the loading.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
